### PR TITLE
chore: update buildAndDeploy runner, update docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   BuildAndDeploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -1,9 +1,10 @@
 name: Publish image to GHCR
 
 on:
-  workflow_call:
-  release:
-    types: [published]
+  workflow_dispatch:
+  push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,31 +1,52 @@
 # VeChain Insight
 
-> Insight is a **serverless** VeChain explorer. It allows you to explore and search for blocks, transactions and accounts. 
+> Insight is a **serverless** VeChain explorer. It allows you to explore and search for blocks, transactions and accounts.
 
 [Try it out!](https://insight.vecha.in/#/)
 
 ## Permanent links
 
-* Main net - `https://insight.vecha.in/#/main/txs/{txid}`
-* Test net - `https://insight.vecha.in/#/test/txs/{txid}`
+- Main net - `https://insight.vecha.in/#/main/txs/{txid}`
+- Test net - `https://insight.vecha.in/#/test/txs/{txid}`
 
 ## Screenshots
 
 ![Homepage](./screenshots/homepage-chrome-app.png)
 
 ## Project setup
+
+### Install dependencies
+
 ```
-npm install
+yarn
 ```
 
-### Compiles and hot-reloads for development
+### Compiles with hot-reload for development
+
 ```
-npm run serve
+yarn serve
 ```
 
 ### Compiles and minifies for production
+
 ```
-npm run build
+yarn build
+```
+
+## Build and run with Docker
+
+```
+docker build -t insight-app .
+```
+
+```
+docker run -dp 127.0.0.1:8080:80 insight-app
+```
+
+or with docker compose
+
+```
+docker compose up -d --build
 ```
 
 ## Contributing


### PR DESCRIPTION
- update buildAndDeploy runner to use `ubuntu-latest` (as 18.04 is not supported anymore);
- update README.md to use yarn and docker;
- update `push-docker-image.yml` to be executed on master push;