### PR TITLE
feat: add support for solo network

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,12 @@ RUN --mount=type=bind,source=package.json,target=package.json \
 
 # Copy the rest of the source files into the image.
 COPY . .
+
+ARG VUE_APP_SOLO_URL
+ENV VUE_APP_SOLO_URL=$VUE_APP_SOLO_URL
+
+ENV NODE_ENV=production
+
 # Run the build script.
 RUN yarn run build
 
@@ -50,4 +56,6 @@ FROM nginx:stable-alpine AS final
 COPY --from=build /usr/src/app/dist /usr/share/nginx/html
 # COPY --from=build /usr/src/app/nginx.prod.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
+
 CMD ["nginx", "-g", "daemon off;"]
+

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,40 +11,9 @@ services:
   server:
     build:
       context: .
+      args:
+        - VUE_APP_SOLO_URL=http://localhost:8669
     environment:
       NODE_ENV: production
     ports:
       - 8080:80
-# The commented out section below is an example of how to define a PostgreSQL
-# database that your application can use. `depends_on` tells Docker Compose to
-# start the database before your application. The `db-data` volume persists the
-# database data between container restarts. The `db-password` secret is used
-# to set the database password. You must create `db/password.txt` and add
-# a password of your choosing to it before running `docker-compose up`.
-#     depends_on:
-#       db:
-#         condition: service_healthy
-#   db:
-#     image: postgres
-#     restart: always
-#     user: postgres
-#     secrets:
-#       - db-password
-#     volumes:
-#       - db-data:/var/lib/postgresql/data
-#     environment:
-#       - POSTGRES_DB=example
-#       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
-#     expose:
-#       - 5432
-#     healthcheck:
-#       test: [ "CMD", "pg_isready" ]
-#       interval: 10s
-#       timeout: 5s
-#       retries: 5
-# volumes:
-#   db-data:
-# secrets:
-#   db-password:
-#     file: db/password.txt
-

--- a/src/App.vue
+++ b/src/App.vue
@@ -62,17 +62,18 @@ export default Vue.extend({
         }
     },
     created() {
-        let net = this.$route.params.net as "main" | "test" | undefined
-        if (!["main", "test"].includes(net!)) {
+        let net = this.$route.params.net as "main" | "test" | "solo" | undefined
+        if (!["main", "test", "solo"].includes(net!)) {
             net = undefined
         }
 
         const connex = createConnex(net)
         Vue.prototype.$connex = connex
         Vue.prototype.$net = genesisIdToNetwork(connex.thor.genesis.id)
-        if (!["main", "test"].includes(Vue.prototype.$net)) {
+        if (!["main", "test", "solo"].includes(Vue.prototype.$net)) {
             Vue.prototype.$net = undefined
         }
+
 
         this.routed()
 

--- a/src/create-connex.ts
+++ b/src/create-connex.ts
@@ -1,22 +1,49 @@
-import Connex from '@vechain/connex/esm'
+import Connex from "@vechain/connex/esm";
 
 const nodeUrls = {
-    main: 'https://explore-mainnet.veblocks.net',
-    test: 'https://explore-testnet.veblocks.net'
-}
+  main: "https://explore-mainnet.veblocks.net",
+  test: "https://explore-testnet.veblocks.net",
+  solo: process.env.VUE_APP_SOLO_URL ?? "http://localhost:8669",
+};
 
-export function createConnex(net?: 'main' | 'test') {
-    if (net) { // net specified
-        const url = nodeUrls[net]
-        return new Connex({ node: url, network: net })
-    } else {
-        const injected = (window as any).connex
-        // net unspecified
-        if (injected) {
-            return new Connex({ node: '', network: injected.thor.genesis })
-        } else {
-            // defaults to main net
-            return new Connex({ node: nodeUrls.main })
-        }
+const soloGenesis = {
+  number: 0,
+  id: "0x00000000c05a20fbca2bf6ae3affba6af4a74b800b585bf7a4988aba7aea69f6",
+  size: 170,
+  parentID:
+    "0xffffffff53616c757465202620526573706563742c20457468657265756d2100",
+  timestamp: 1530316800,
+  gasLimit: 10000000,
+  beneficiary: "0x0000000000000000000000000000000000000000",
+  gasUsed: 0,
+  totalScore: 0,
+  txsRoot: "0x45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0",
+  txsFeatures: 0,
+  stateRoot:
+    "0x93de0ffb1f33bc0af053abc2a87c4af44594f5dcb1cb879dd823686a15d68550",
+  receiptsRoot:
+    "0x45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0",
+  signer: "0x0000000000000000000000000000000000000000",
+  isTrunk: true,
+  transactions: [],
+};
+
+export function createConnex(net?: "main" | "test" | "solo") {
+  if (net) {
+    // net specified
+    const url = nodeUrls[net];
+    if (net == "solo") {
+      return new Connex({ node: url, network: soloGenesis });
     }
+    return new Connex({ node: url, network: net });
+  } else {
+    const injected = (window as any).connex;
+    // net unspecified
+    if (injected) {
+      return new Connex({ node: "", network: injected.thor.genesis });
+    } else {
+      // defaults to main net
+      return new Connex({ node: nodeUrls.main });
+    }
+  }
 }

--- a/src/create-connex.ts
+++ b/src/create-connex.ts
@@ -1,9 +1,10 @@
 import Connex from "@vechain/connex/esm";
 
-const nodeUrls = {
+export const nodeUrls = {
   main: "https://explore-mainnet.veblocks.net",
   test: "https://explore-testnet.veblocks.net",
   solo: process.env.VUE_APP_SOLO_URL ?? "http://localhost:8669",
+  custom: process.env.VUE_APP_CUSTOM_URL ?? "http://localhost:8669",
 };
 
 const soloGenesis = {

--- a/src/create-connex.ts
+++ b/src/create-connex.ts
@@ -1,10 +1,14 @@
 import Connex from "@vechain/connex/esm";
 
+export const soloUrlNode = process.env.VUE_APP_SOLO_URL;
+
+//Needed to support runtime env variables
+export const isSoloNode = !!soloUrlNode;
 export const nodeUrls = {
   main: "https://explore-mainnet.veblocks.net",
   test: "https://explore-testnet.veblocks.net",
-  solo: process.env.VUE_APP_SOLO_URL ?? "http://localhost:8669",
-  custom: process.env.VUE_APP_CUSTOM_URL ?? "http://localhost:8669",
+  solo: soloUrlNode ?? "http://localhost:8669",
+  custom: "",
 };
 
 const soloGenesis = {
@@ -43,7 +47,10 @@ export function createConnex(net?: "main" | "test" | "solo") {
     if (injected) {
       return new Connex({ node: "", network: injected.thor.genesis });
     } else {
-      // defaults to main net
+      // defaults to main net, or soloUrl if solo is provided
+      if (isSoloNode) {
+        return new Connex({ node: nodeUrls.solo, network: soloGenesis });
+      }
       return new Connex({ node: nodeUrls.main });
     }
   }

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,73 +1,78 @@
-import Vue from 'vue'
-import Router from 'vue-router'
-import Frame from './views/Frame.vue'
-import Home from './views/Home.vue'
-import Account from './views/Account.vue'
-import Block from './views/Block.vue'
-import Tx from './views/Tx.vue'
-import Search from './views/Search.vue'
+import Vue from "vue";
+import Router from "vue-router";
+import Frame from "./views/Frame.vue";
+import Home from "./views/Home.vue";
+import Account from "./views/Account.vue";
+import Block from "./views/Block.vue";
+import Tx from "./views/Tx.vue";
+import Search from "./views/Search.vue";
 
-import AccountSummary from './views/AccountSummary.vue'
-import AccountEvents from './views/AccountEvents.vue'
-import AccountTransfers from './views/AccountTransfers.vue'
+import AccountSummary from "./views/AccountSummary.vue";
+import AccountEvents from "./views/AccountEvents.vue";
+import AccountTransfers from "./views/AccountTransfers.vue";
 
-Vue.use(Router)
+Vue.use(Router);
 
 export default new Router({
-    mode: 'hash',
-    routes: [
+  mode: "hash",
+  routes: [
+    {
+      path: "/:net(main|test|solo)?",
+      children: [
         {
-            path: '/:net(main|test)?',
-            children: [
-                {
-                    path: '',
-                    name: 'home',
-                    component: Home,
-                },
-                {
-                    path: 'blocks/:id',
-                    name: 'block',
-                    component: Block
-                },
-                {
-                    path: 'txs/:id',
-                    name: 'tx',
-                    component: Tx
-                },
-                {
-                    path: 'accounts/:address',
-                    component: Account,
-                    name: 'account',
-                    redirect: { name: 'summary' },
-                    children: [{
-                        name: 'summary',
-                        path: '',
-                        component: AccountSummary
-                    }, {
-                        name: 'transfers',
-                        path: 'transfers',
-                        component: AccountTransfers
-                    }, {
-                        name: 'events',
-                        path: 'events',
-                        component: AccountEvents
-                    }, {
-                        name: 'deposit',
-                        path: 'deposit',
-                        component: AccountSummary,
-                    }]
-                },
-                {
-                    path: 'search',
-                    name: 'search',
-                    component: Search
-                }
-            ],
-            component: Frame
+          path: "",
+          name: "home",
+          component: Home,
         },
         {
-            path: '*',
-            redirect: { name: 'home' }
-        }
-    ]
-})
+          path: "blocks/:id",
+          name: "block",
+          component: Block,
+        },
+        {
+          path: "txs/:id",
+          name: "tx",
+          component: Tx,
+        },
+        {
+          path: "accounts/:address",
+          component: Account,
+          name: "account",
+          redirect: { name: "summary" },
+          children: [
+            {
+              name: "summary",
+              path: "",
+              component: AccountSummary,
+            },
+            {
+              name: "transfers",
+              path: "transfers",
+              component: AccountTransfers,
+            },
+            {
+              name: "events",
+              path: "events",
+              component: AccountEvents,
+            },
+            {
+              name: "deposit",
+              path: "deposit",
+              component: AccountSummary,
+            },
+          ],
+        },
+        {
+          path: "search",
+          name: "search",
+          component: Search,
+        },
+      ],
+      component: Frame,
+    },
+    {
+      path: "*",
+      redirect: { name: "home" },
+    },
+  ],
+});

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,78 +1,73 @@
-import Vue from "vue";
-import Router from "vue-router";
-import Frame from "./views/Frame.vue";
-import Home from "./views/Home.vue";
-import Account from "./views/Account.vue";
-import Block from "./views/Block.vue";
-import Tx from "./views/Tx.vue";
-import Search from "./views/Search.vue";
+import Vue from 'vue'
+import Router from 'vue-router'
+import Frame from './views/Frame.vue'
+import Home from './views/Home.vue'
+import Account from './views/Account.vue'
+import Block from './views/Block.vue'
+import Tx from './views/Tx.vue'
+import Search from './views/Search.vue'
 
-import AccountSummary from "./views/AccountSummary.vue";
-import AccountEvents from "./views/AccountEvents.vue";
-import AccountTransfers from "./views/AccountTransfers.vue";
+import AccountSummary from './views/AccountSummary.vue'
+import AccountEvents from './views/AccountEvents.vue'
+import AccountTransfers from './views/AccountTransfers.vue'
 
-Vue.use(Router);
+Vue.use(Router)
 
 export default new Router({
-  mode: "hash",
-  routes: [
-    {
-      path: "/:net(main|test|solo)?",
-      children: [
+    mode: 'hash',
+    routes: [
         {
-          path: "",
-          name: "home",
-          component: Home,
+            path: '/:net(main|test|solo)?',
+            children: [
+                {
+                    path: '',
+                    name: 'home',
+                    component: Home,
+                },
+                {
+                    path: 'blocks/:id',
+                    name: 'block',
+                    component: Block
+                },
+                {
+                    path: 'txs/:id',
+                    name: 'tx',
+                    component: Tx
+                },
+                {
+                    path: 'accounts/:address',
+                    component: Account,
+                    name: 'account',
+                    redirect: { name: 'summary' },
+                    children: [{
+                        name: 'summary',
+                        path: '',
+                        component: AccountSummary
+                    }, {
+                        name: 'transfers',
+                        path: 'transfers',
+                        component: AccountTransfers
+                    }, {
+                        name: 'events',
+                        path: 'events',
+                        component: AccountEvents
+                    }, {
+                        name: 'deposit',
+                        path: 'deposit',
+                        component: AccountSummary,
+                    }]
+                },
+                {
+                    path: 'search',
+                    name: 'search',
+                    component: Search
+                }
+            ],
+            component: Frame
         },
         {
-          path: "blocks/:id",
-          name: "block",
-          component: Block,
-        },
-        {
-          path: "txs/:id",
-          name: "tx",
-          component: Tx,
-        },
-        {
-          path: "accounts/:address",
-          component: Account,
-          name: "account",
-          redirect: { name: "summary" },
-          children: [
-            {
-              name: "summary",
-              path: "",
-              component: AccountSummary,
-            },
-            {
-              name: "transfers",
-              path: "transfers",
-              component: AccountTransfers,
-            },
-            {
-              name: "events",
-              path: "events",
-              component: AccountEvents,
-            },
-            {
-              name: "deposit",
-              path: "deposit",
-              component: AccountSummary,
-            },
-          ],
-        },
-        {
-          path: "search",
-          name: "search",
-          component: Search,
-        },
-      ],
-      component: Frame,
-    },
-    {
-      path: "*",
-      redirect: { name: "home" },
-    },
-  ],
-});
+            path: '*',
+            redirect: { name: 'home' }
+        }
+    ]
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,25 @@
 export function genesisIdToNetwork(id: string) {
-    switch (id) {
-        case '0x00000000851caf3cfdb6e899cf5958bfb1ac3413d346d43539627e6be7ec1b4a': return 'main'
-        case '0x000000000b2bce3c70bc649a02749e8687721b09ed2e15997f466536b20bb127': return 'test'
-        case '0x00000000c05a20fbca2bf6ae3affba6af4a74b800b585bf7a4988aba7aea69f6': return 'solo'
-        default: return 'custom'
-    }
+  switch (id) {
+    case "0x00000000851caf3cfdb6e899cf5958bfb1ac3413d346d43539627e6be7ec1b4a":
+      return "main";
+    case "0x000000000b2bce3c70bc649a02749e8687721b09ed2e15997f466536b20bb127":
+      return "test";
+    case "0x00000000c05a20fbca2bf6ae3affba6af4a74b800b585bf7a4988aba7aea69f6":
+      return "solo";
+    default:
+      return "custom";
+  }
+}
+
+export function networkToGenesisId(net: string) {
+  switch (net) {
+    case "main":
+      return "0x00000000851caf3cfdb6e899cf5958bfb1ac3413d346d43539627e6be7ec1b4a";
+    case "test":
+      return "0x000000000b2bce3c70bc649a02749e8687721b09ed2e15997f466536b20bb127";
+    case "solo":
+      return "0x00000000c05a20fbca2bf6ae3affba6af4a74b800b585bf7a4988aba7aea69f6";
+    default:
+      return "";
+  }
 }

--- a/src/views/Frame.vue
+++ b/src/views/Frame.vue
@@ -28,7 +28,7 @@
                             v-for="(n, i) in switchableNetworks"
                             :key="i"
                             :href="n.href"
-                        >{{n.name}}</b-dropdown-item>
+                        >{{n.label}}</b-dropdown-item>
                     </b-dropdown>
                     </div>
                     <div class="d-flex align-items-center">
@@ -135,8 +135,12 @@
 </template>
 <script lang="ts">
 import Vue from 'vue'
-import { genesisIdToNetwork } from '../utils'
+import { genesisIdToNetwork, networkToGenesisId } from '../utils'
 import { nodeUrls } from '@/create-connex'
+
+const isSoloUrl = !!process.env.VUE_APP_SOLO_URL
+const isCustomurl = !!process.env.VUE_APP_CUSTOM_URL
+
 
 export default Vue.extend({
     data: () => {
@@ -157,15 +161,16 @@ export default Vue.extend({
                 case 'custom': return `Custom:0x${this.$connex.thor.genesis.id.slice(-2)}`
             }
         },
-        switchableNetworks(): Array<{ name: string, href: string }> {
-            switch (genesisIdToNetwork(this.$connex.thor.genesis.id)) {
-                case 'main': return [{ name: 'TestNet', href: '#/test/' }, { name: 'SoloNet', href: '#/solo/' }]
-                case 'test': return [{ name: 'MainNet', href: '#/main/' }, { name: 'SoloNet', href: '#/solo/' }]
-                case 'solo': return [{ name: 'MainNet', href: '#/main/' }, { name: 'TestNet', href: '#/test/' }]
-                default: return [{ name: 'TestNet', href: '#/test/' },
-                { name: 'MainNet', href: '#/main/' },
-                { name: 'Solo', href: '#/solo/' }]
-            }
+        networks(): Array<{ name: string, label: string, href: string }> {
+            return [
+                { name: 'main',label: 'MainNet', href: '#/main/' },
+                { name: 'test',label: 'TestNet', href: '#/test/' },
+                ...(isSoloUrl ? [{ name:'solo',label: 'SoloNet', href: '#/solo/' }] : []),
+                ...(isCustomurl ? [{ name:'custom',label: `Custom:0x${this.$connex.thor.genesis.id.slice(-2)}`, href: '#/custom/' }] : [])
+            ]
+        },
+        switchableNetworks(): Array<{ name: string, label: string, href: string }> {
+            return this.networks.filter(i =>  this.$connex.thor.genesis.id !== networkToGenesisId(i.name))
         },
         networkBadgeVariant() {
             return genesisIdToNetwork(this.$connex.thor.genesis.id) === 'main' ? 'light' : 'warning'

--- a/src/views/Frame.vue
+++ b/src/views/Frame.vue
@@ -16,7 +16,9 @@
                         <span class="text-serif h4">Insight</span>
                     </router-link>
                     
+                    <b-badge v-if="networks.length === 1" :variant="networkBadgeVariant" size="sm" class="ml-4">{{networks[0].label}}</b-badge>
                     <b-dropdown
+                        v-if="networks.length > 1"
                         size="sm"
                         :text="network"
                         :variant="networkBadgeVariant"
@@ -136,10 +138,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { genesisIdToNetwork, networkToGenesisId } from '../utils'
-import { nodeUrls } from '@/create-connex'
+import { nodeUrls, isSoloNode} from '@/create-connex'
 
-const isSoloUrl = !!process.env.VUE_APP_SOLO_URL
-const isCustomurl = !!process.env.VUE_APP_CUSTOM_URL
 
 
 export default Vue.extend({
@@ -158,15 +158,18 @@ export default Vue.extend({
                 case 'main': return 'MainNet'
                 case 'test': return 'TestNet'
                 case 'solo': return 'SoloNet'
-                case 'custom': return `Custom:0x${this.$connex.thor.genesis.id.slice(-2)}`
             }
         },
         networks(): Array<{ name: string, label: string, href: string }> {
+            if(isSoloNode) return [ {
+                name: 'solo',
+                label: 'SoloNet',
+                href: '#/solo/'
+                }]
             return [
                 { name: 'main',label: 'MainNet', href: '#/main/' },
                 { name: 'test',label: 'TestNet', href: '#/test/' },
-                ...(isSoloUrl ? [{ name:'solo',label: 'SoloNet', href: '#/solo/' }] : []),
-                ...(isCustomurl ? [{ name:'custom',label: `Custom:0x${this.$connex.thor.genesis.id.slice(-2)}`, href: '#/custom/' }] : [])
+                ...(isSoloNode ? [{ name:'solo',label: 'SoloNet', href: '#/solo/' }] : []),
             ]
         },
         switchableNetworks(): Array<{ name: string, label: string, href: string }> {

--- a/src/views/Frame.vue
+++ b/src/views/Frame.vue
@@ -47,18 +47,19 @@
                 >
                     <b-navbar-nav class="ml-auto">
                         <template v-if="price">
+                            
                             <b-nav-item
-                                class="text-monospace small"
+                                class="text-monospace small d-flex align-items-center"
                                 href="https://www.coingecko.com/en/coins/vechain"
                                 target="_blank"
                             >
                                 <div class="small">
-                                    &nbsp;VET
+                                    VET
                                     <span class="text-light">${{price.vet.toFixed(5)}}</span>
                                 </div>
                             </b-nav-item>
                             <b-nav-item
-                                class="text-monospace small mr-3"
+                                class="text-monospace small mr-3 d-flex align-items-center"
                                 href="https://www.coingecko.com/en/coins/vethor-token"
                                 target="_blank"
                             >
@@ -149,7 +150,7 @@ export default Vue.extend({
         }
     },
     computed: {
-        routeName(): string { return this.$route.name || '' },
+        routeName(): string { return this.$route.name ?? '' },
         isHome(): boolean { return this.routeName === 'home' },
         price() { return this.$state.price },
         nodeUrl() { return nodeUrls[genesisIdToNetwork(this.$connex.thor.genesis.id)] },

--- a/src/views/Frame.vue
+++ b/src/views/Frame.vue
@@ -7,19 +7,22 @@
         >
             <div class="container">
                 <b-navbar-brand>
+                    
+                    <div class="d-flex align-items-center d-flex-row">
                     <router-link
                         :to="{name:'home', params: {net:$net}}"
                         class="text-decoration-none text-white"
                     >
                         <span class="text-serif h4">Insight</span>
                     </router-link>
+                    
                     <b-dropdown
                         size="sm"
                         :text="network"
                         :variant="networkBadgeVariant"
                         toggle-class="py-0 px-1"
                         style="vertical-align:top"
-                        class="ml-2"
+                        class="ml-4"
                     >
                         <b-dropdown-item
                             v-for="(n, i) in switchableNetworks"
@@ -27,7 +30,14 @@
                             :href="n.href"
                         >{{n.name}}</b-dropdown-item>
                     </b-dropdown>
+                    </div>
+                    <div class="d-flex align-items-center">
+                    <span class="text-monospace small light ">
+                        {{nodeUrl}}
+                    </span>
+                    </div>
                 </b-navbar-brand>
+
                 <b-navbar-toggle target="nav_collapse" />
                 <b-collapse
                     is-nav
@@ -126,6 +136,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import { genesisIdToNetwork } from '../utils'
+import { nodeUrls } from '@/create-connex'
 
 export default Vue.extend({
     data: () => {
@@ -137,6 +148,7 @@ export default Vue.extend({
         routeName(): string { return this.$route.name || '' },
         isHome(): boolean { return this.routeName === 'home' },
         price() { return this.$state.price },
+        nodeUrl() { return nodeUrls[genesisIdToNetwork(this.$connex.thor.genesis.id)] },
         network() {
             switch (genesisIdToNetwork(this.$connex.thor.genesis.id)) {
                 case 'main': return 'MainNet'

--- a/src/views/Frame.vue
+++ b/src/views/Frame.vue
@@ -141,15 +141,18 @@ export default Vue.extend({
             switch (genesisIdToNetwork(this.$connex.thor.genesis.id)) {
                 case 'main': return 'MainNet'
                 case 'test': return 'TestNet'
-                case 'solo': return 'Solo'
+                case 'solo': return 'SoloNet'
                 case 'custom': return `Custom:0x${this.$connex.thor.genesis.id.slice(-2)}`
             }
         },
         switchableNetworks(): Array<{ name: string, href: string }> {
             switch (genesisIdToNetwork(this.$connex.thor.genesis.id)) {
-                case 'main': return [{ name: 'TestNet', href: '#/test/' }]
-                case 'test': return [{ name: 'MainNet', href: '#/main/' }]
-                default: return [{ name: 'TestNet', href: '#/test/' }, { name: 'MainNet', href: '#/main/' }]
+                case 'main': return [{ name: 'TestNet', href: '#/test/' }, { name: 'SoloNet', href: '#/solo/' }]
+                case 'test': return [{ name: 'MainNet', href: '#/main/' }, { name: 'SoloNet', href: '#/solo/' }]
+                case 'solo': return [{ name: 'MainNet', href: '#/main/' }, { name: 'TestNet', href: '#/test/' }]
+                default: return [{ name: 'TestNet', href: '#/test/' },
+                { name: 'MainNet', href: '#/main/' },
+                { name: 'Solo', href: '#/solo/' }]
             }
         },
         networkBadgeVariant() {

--- a/src/views/Frame.vue
+++ b/src/views/Frame.vue
@@ -32,9 +32,9 @@
                     </b-dropdown>
                     </div>
                     <div class="d-flex align-items-center">
-                    <span class="text-monospace small light ">
-                        {{nodeUrl}}
-                    </span>
+                        <span class="text-monospace" style="font-size: x-small;">
+                            {{nodeUrl}}
+                        </span>
                     </div>
                 </b-navbar-brand>
 


### PR DESCRIPTION
This PR integrates the support of an optional solo url provided via env config.
This is mostly to provide a better DX for local development, especially when spinning up the app using docker and compose.
As part of this PR, in order to provide more info about the connected node, we are also displaying the node url

Specifically:
- if no `VITE_APP_SOLO_URL` is provided, t**he behaviour of the dapp does not change**. Only Mainnet and TestNet are available in the network selector, and mainnet is the default network;
<img width="454" alt="Screenshot 2024-03-12 at 11 09 03" src="https://github.com/vechain/insight-app/assets/15635248/595dfe48-f957-4c60-b1b5-ddfa8cf6da97">

- If `VITE_APP_SOLO_URL` is provided, the app tries to connect by default to that specific network. Network switcher is hidden, and the network is displayed in a badge;
<img width="420" alt="Screenshot 2024-03-12 at 11 08 34" src="https://github.com/vechain/insight-app/assets/15635248/a3618d11-ff4f-4cb5-8aeb-0c72638efddf">


Since the app is built as served statically, is not possible to pass the env variable using docker `env_file` or `environment`. Instead, we need to pass it via build args as done in the `compose.yaml` file




